### PR TITLE
Implement Julian day conversion and ephemeris wrapper

### DIFF
--- a/vedic_time_engine/app/core/sun_moon.py
+++ b/vedic_time_engine/app/core/sun_moon.py
@@ -1,6 +1,34 @@
-"""Placeholder for sun_moon calculations."""
+"""Utilities for Sun and Moon longitude calculations using Swiss Ephemeris."""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime
+from typing import Tuple
+
+from dotenv import load_dotenv
+import swisseph as swe
 
 
-def calculate_sun_moon(*args, **kwargs):
-    """Calculate sun_moon."""
-    pass
+load_dotenv()
+swe.set_ephe_path(os.getenv("SWISSEPH_PATH", "ephe/"))
+
+
+def to_julian_day(date_str: str) -> float:
+    """Convert a ``YYYY-MM-DD`` date string to Julian Day at 0h UT."""
+
+    dt = datetime.strptime(date_str, "%Y-%m-%d")
+    return swe.julday(dt.year, dt.month, dt.day, 0.0, swe.GREG_CAL)
+
+
+class EphemerisCalculator:
+    """Wrapper to obtain Sun and Moon geocentric longitudes."""
+
+    def get_sun_moon_longitudes(self, jd: float) -> Tuple[float, float]:
+        """Return the Sun and Moon ecliptic longitudes for ``jd`` (UT)."""
+
+        flags = swe.FLG_SWIEPH
+        sun_pos, _ = swe.calc_ut(jd, swe.SUN, flags)
+        moon_pos, _ = swe.calc_ut(jd, swe.MOON, flags)
+        return sun_pos[0], moon_pos[0]
+


### PR DESCRIPTION
## Summary
- implement `to_julian_day` helper to convert YYYY-MM-DD to JD
- create `EphemerisCalculator` to read Swiss Ephemeris path and return Sun/Moon longitudes

## Testing
- `python - <<'EOF'
from vedic_time_engine.app.core.sun_moon import to_julian_day, EphemerisCalculator
jd = to_julian_day('2023-01-01')
calc = EphemerisCalculator()
print(jd)
print(calc.get_sun_moon_longitudes(jd))
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6878eaa16be0832a83f7b40569b5080f