### PR TITLE
Implement tithi calculations

### DIFF
--- a/vedic_time_engine/__init__.py
+++ b/vedic_time_engine/__init__.py
@@ -1,0 +1,1 @@
+# Vedic Time Engine package

--- a/vedic_time_engine/app/core/tithi.py
+++ b/vedic_time_engine/app/core/tithi.py
@@ -1,6 +1,21 @@
-"""Placeholder for tithi calculations."""
+"""Tithi (lunar day) calculations."""
+
+from ...i18n import get_translation
+
+
+def get_tithi_index(moon_lon: float, sun_lon: float) -> int:
+    """Return the tithi index based on longitudinal difference."""
+    difference = (moon_lon - sun_lon) % 360
+    index = int(difference // 12)
+    return index
+
+
+def get_tithi_name(index: int, lang: str = "en") -> str:
+    """Return the localized name for the given tithi index."""
+    index = index % 30
+    return get_translation(f"tithi.{index}", lang)
 
 
 def calculate_tithi(*args, **kwargs):
-    """Calculate tithi."""
-    pass
+    """Backward-compatible placeholder for tithi calculation."""
+    return get_tithi_index(*args, **kwargs)

--- a/vedic_time_engine/i18n/__init__.py
+++ b/vedic_time_engine/i18n/__init__.py
@@ -1,0 +1,23 @@
+import json
+from functools import lru_cache
+from pathlib import Path
+
+_I18N_DIR = Path(__file__).parent
+
+@lru_cache(maxsize=None)
+def _load_language(lang: str) -> dict:
+    """Load translation dictionary for a given language."""
+    path = _I18N_DIR / f"{lang}.json"
+    if not path.exists():
+        return {}
+    with open(path, "r", encoding="utf-8") as f:
+        try:
+            return json.load(f)
+        except json.JSONDecodeError:
+            return {}
+
+
+def get_translation(key: str, lang: str = "en") -> str:
+    """Return the translated string for the given key and language."""
+    translations = _load_language(lang)
+    return translations.get(key, key)

--- a/vedic_time_engine/tests/test_tithi.py
+++ b/vedic_time_engine/tests/test_tithi.py
@@ -1,0 +1,21 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from vedic_time_engine.app.core.tithi import get_tithi_index, get_tithi_name
+
+
+def test_get_tithi_index_basic():
+    assert get_tithi_index(0, 0) == 0
+    assert get_tithi_index(13, 0) == 1
+    assert get_tithi_index(359, 0) == 29
+
+
+def test_get_tithi_name_fallback():
+    # With empty translations, returns key
+    assert get_tithi_name(0, "en") == "tithi.0"
+    assert get_tithi_name(5, "en") == "tithi.5"
+


### PR DESCRIPTION
## Summary
- implement `get_tithi_index` and `get_tithi_name` in `tithi.py`
- add simple i18n loader for translations
- add package init file and tests for tithi logic

## Testing
- `pip install` dependencies (except pinned pyswisseph)
- `pip install pyswisseph==2.10.3.2`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878ec1ba9d8832aad4e43f3d4c2d5ef