### PR TITLE
Add nakshatra utilities

### DIFF
--- a/vedic_time_engine/app/core/nakshatra.py
+++ b/vedic_time_engine/app/core/nakshatra.py
@@ -1,6 +1,52 @@
-"""Placeholder for nakshatra calculations."""
+"""Nakshatra calculation utilities."""
+
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+
+
+I18N_DIR = Path(__file__).resolve().parents[2] / "i18n"
+
+
+@lru_cache(maxsize=None)
+def _load_translations(lang: str) -> dict:
+    """Load translation dictionary for ``lang`` from JSON files."""
+
+    file_path = I18N_DIR / f"{lang}.json"
+    if not file_path.exists():
+        return {}
+    try:
+        with open(file_path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception:
+        return {}
+
+
+def get_translation(key: str, lang: str = "en") -> str:
+    """Return the localized string for ``key`` or the key if missing."""
+
+    translations = _load_translations(lang)
+    return translations.get(key, key)
+
+
+def get_nakshatra_index(moon_lon: float) -> int:
+    """Return the 0-based nakshatra index for ``moon_lon`` in degrees."""
+
+    segment = 360.0 / 27.0
+    return int((moon_lon % 360.0) // segment)
+
+
+def get_nakshatra_name(index: int, lang: str = "en") -> str:
+    """Return the localized name of the nakshatra at ``index``."""
+
+    wrapped_index = index % 27
+    key = f"nakshatra.{wrapped_index}"
+    return get_translation(key, lang)
 
 
 def calculate_nakshatra(*args, **kwargs):
-    """Calculate nakshatra."""
+    """Calculate nakshatra (placeholder)."""
+
     pass

--- a/vedic_time_engine/tests/test_nakshatra.py
+++ b/vedic_time_engine/tests/test_nakshatra.py
@@ -1,0 +1,18 @@
+import importlib
+from vedic_time_engine.app.core.nakshatra import get_nakshatra_index, get_nakshatra_name
+
+
+def test_get_nakshatra_index_basic():
+    assert get_nakshatra_index(0) == 0
+    assert get_nakshatra_index(13.333333) == 0  # still in first nakshatra
+    assert get_nakshatra_index(13.3334) == 1
+
+
+def test_get_nakshatra_index_wrap():
+    assert get_nakshatra_index(360) == 0
+    assert get_nakshatra_index(-0.1) == 26
+
+
+def test_get_nakshatra_name_fallback():
+    # translations are empty so fallback to key
+    assert get_nakshatra_name(0, "en") == "nakshatra.0"


### PR DESCRIPTION
## Summary
- implement index and name lookup for nakshatra
- add a minimal translation loader with fallback
- test nakshatra index and name functions

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878ec5a06dc832a92f42d40018d248a