### PR TITLE
Implement Ghati/Vighati utility

### DIFF
--- a/tests/test_ghati.py
+++ b/tests/test_ghati.py
@@ -1,0 +1,19 @@
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from vedic_time_engine.app.core.ghati import get_ghati_vighati
+
+def test_five_hours_since_sunrise():
+    assert get_ghati_vighati("06:00", "11:00") == (12, 30)
+
+def test_before_sunrise_clamped():
+    assert get_ghati_vighati("06:00", "05:00") == (0, 0)
+
+def test_exact_ghati_boundary():
+    assert get_ghati_vighati("06:00", "06:24") == (1, 0)
+
+def test_single_minute():
+    assert get_ghati_vighati("06:00", "06:01") == (0, 2)

--- a/vedic_time_engine/app/core/ghati.py
+++ b/vedic_time_engine/app/core/ghati.py
@@ -1,4 +1,41 @@
-"""Placeholder for ghati calculations."""
+"""Utility functions for Ghati/Vighati time calculations."""
+
+from typing import Tuple
+
+
+def get_ghati_vighati(sunrise: str, current_time: str) -> Tuple[int, int]:
+    """Return the ghati and vighati elapsed since ``sunrise``.
+
+    Parameters
+    ----------
+    sunrise : str
+        Local sunrise time in ``"HH:MM"`` 24‑hour format.
+    current_time : str
+        Local current time in ``"HH:MM"`` 24‑hour format.
+
+    Returns
+    -------
+    Tuple[int, int]
+        Number of ghatis and vighatis elapsed since ``sunrise``. Both values
+        are clamped to the range 0–59.
+    """
+
+    def to_minutes(value: str) -> int:
+        hours, minutes = map(int, value.split(":"))
+        return hours * 60 + minutes
+
+    sunrise_min = to_minutes(sunrise)
+    current_min = to_minutes(current_time)
+
+    total_minutes = current_min - sunrise_min
+    if total_minutes < 0:
+        total_minutes = 0
+
+    ghati = (total_minutes // 24) % 60
+    leftover_minutes = total_minutes % 24
+    vighati = int(leftover_minutes * 60 / 24) % 60
+
+    return ghati, vighati
 
 
 def calculate_ghati(*args, **kwargs):


### PR DESCRIPTION
## Summary
- implement `get_ghati_vighati` to compute elapsed ghatis and vighatis
- make `vedic_time_engine` a package
- add unit tests for new function

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878ecd34628832aaa63188dd68afc93