### PR TITLE
Implement basic festival detection

### DIFF
--- a/vedic_time_engine/app/core/festivals.py
+++ b/vedic_time_engine/app/core/festivals.py
@@ -1,6 +1,50 @@
-"""Placeholder for festivals calculations."""
+"""Festival determination utilities."""
+
+from __future__ import annotations
+
+from typing import List
+
+from ..i18n import get_translation
+
+
+def get_festivals(
+    tithi_index: int,
+    nakshatra_index: int,
+    paksha: str,
+    maasa: str,
+    lang: str = "en",
+) -> List[str]:
+    """Return a list of festivals for the given Panchang elements.
+
+    Parameters
+    ----------
+    tithi_index:
+        Index of the current tithi (0-based).
+    nakshatra_index:
+        Index of the current nakshatra (0-based).
+    paksha:
+        Either ``"Shukla"`` or ``"Krishna"``.
+    maasa:
+        Name of the lunar month (unused for the sample rules).
+    lang:
+        Target language for festival names.
+    """
+
+    festivals: List[str] = []
+
+    # Janmashtami: Krishna Ashtami with Rohini nakshatra
+    if paksha == "Krishna" and tithi_index == 7 and nakshatra_index == 3:
+        festivals.append(get_translation("festival.janmashtami", lang))
+
+    # Vinayaka Chaturthi: Shukla Chaturthi
+    if paksha == "Shukla" and tithi_index == 3:
+        festivals.append(get_translation("festival.vinayaka_chaturthi", lang))
+
+    return festivals
 
 
 def calculate_festivals(*args, **kwargs):
-    """Calculate festivals."""
-    pass
+    """Backward-compatible placeholder for festival calculations."""
+
+    return get_festivals(*args, **kwargs)
+

--- a/vedic_time_engine/i18n/en.json
+++ b/vedic_time_engine/i18n/en.json
@@ -1,1 +1,4 @@
-{}
+{
+    "festival.janmashtami": "Janmashtami",
+    "festival.vinayaka_chaturthi": "Vinayaka Chaturthi"
+}

--- a/vedic_time_engine/i18n/hi.json
+++ b/vedic_time_engine/i18n/hi.json
@@ -1,1 +1,4 @@
-{}
+{
+    "festival.janmashtami": "जन्माष्टमी",
+    "festival.vinayaka_chaturthi": "विनायक चतुर्थी"
+}

--- a/vedic_time_engine/i18n/mr.json
+++ b/vedic_time_engine/i18n/mr.json
@@ -1,1 +1,4 @@
-{}
+{
+    "festival.janmashtami": "जन्माष्टमी",
+    "festival.vinayaka_chaturthi": "विनायक चतुर्थी"
+}

--- a/vedic_time_engine/i18n/ta.json
+++ b/vedic_time_engine/i18n/ta.json
@@ -1,1 +1,4 @@
-{}
+{
+    "festival.janmashtami": "கிருஷ்ண ஜயந்தி",
+    "festival.vinayaka_chaturthi": "விநாயகர் சதுர்த்தி"
+}

--- a/vedic_time_engine/i18n/te.json
+++ b/vedic_time_engine/i18n/te.json
@@ -1,1 +1,4 @@
-{}
+{
+    "festival.janmashtami": "శ్రీకృష్ణ జన్మాష్టమి",
+    "festival.vinayaka_chaturthi": "వినాయక చవితి"
+}


### PR DESCRIPTION
## Summary
- add localized festival detection logic for Janmashtami and Vinayaka Chaturthi
- hook new detection from calculate_festivals
- provide festival name translations for all languages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878f1afe320832aa786feed6605ad60