### PR TITLE
Add language loader with caching

### DIFF
--- a/vedic_time_engine/app/core/choghadiya.py
+++ b/vedic_time_engine/app/core/choghadiya.py
@@ -7,20 +7,15 @@ import os
 from datetime import datetime, timedelta
 from typing import Dict, List
 
+from ..i18n.lang import get_translation as _translate
+
 
 CYCLE = ["Udveg", "Chal", "Labh", "Amrit", "Kaal", "Shubh", "Rog"]
 
 
 def get_translation(key: str, lang: str) -> str:
     """Return translation for ``key`` in ``lang`` if available."""
-    base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
-    file_path = os.path.join(base_dir, "i18n", f"{lang}.json")
-    try:
-        with open(file_path, "r", encoding="utf-8") as fh:
-            data = json.load(fh)
-        return data.get(key, key)
-    except (FileNotFoundError, json.JSONDecodeError):
-        return key
+    return _translate(key, lang)
 
 
 def get_choghadiya_blocks(

--- a/vedic_time_engine/app/core/festivals.py
+++ b/vedic_time_engine/app/core/festivals.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import List
 
-from ..i18n import get_translation
+from ..i18n.lang import get_translation
 
 
 def get_festivals(

--- a/vedic_time_engine/app/core/karana.py
+++ b/vedic_time_engine/app/core/karana.py
@@ -11,6 +11,8 @@ import json
 from functools import lru_cache
 from pathlib import Path
 
+from ..i18n.lang import get_translation as _translate, load_language
+
 
 KARANA_SEQUENCE = [
     "kimstughna",
@@ -41,10 +43,8 @@ def _load_translations(lang: str) -> dict[str, str]:
     key will be returned verbatim.
     """
 
-    base = Path(__file__).resolve().parents[2] / "i18n" / f"{lang}.json"
     try:
-        with base.open(encoding="utf-8") as f:
-            return json.load(f)
+        return load_language(lang)
     except FileNotFoundError:
         return {}
 
@@ -55,7 +55,7 @@ def get_translation(key: str, lang: str = "en") -> str:
     Falls back to ``key`` if the translation is unavailable.
     """
 
-    return _load_translations(lang).get(key, key)
+    return _translate(key, lang)
 
 
 def get_karana_name(index: int, lang: str = "en") -> str:

--- a/vedic_time_engine/app/core/nakshatra.py
+++ b/vedic_time_engine/app/core/nakshatra.py
@@ -6,6 +6,8 @@ import json
 from functools import lru_cache
 from pathlib import Path
 
+from ..i18n.lang import get_translation as _translate, load_language
+
 
 I18N_DIR = Path(__file__).resolve().parents[2] / "i18n"
 
@@ -18,8 +20,7 @@ def _load_translations(lang: str) -> dict:
     if not file_path.exists():
         return {}
     try:
-        with open(file_path, "r", encoding="utf-8") as f:
-            return json.load(f)
+        return load_language(lang)
     except Exception:
         return {}
 
@@ -27,8 +28,7 @@ def _load_translations(lang: str) -> dict:
 def get_translation(key: str, lang: str = "en") -> str:
     """Return the localized string for ``key`` or the key if missing."""
 
-    translations = _load_translations(lang)
-    return translations.get(key, key)
+    return _translate(key, lang)
 
 
 def get_nakshatra_index(moon_lon: float) -> int:

--- a/vedic_time_engine/app/core/tithi.py
+++ b/vedic_time_engine/app/core/tithi.py
@@ -1,6 +1,6 @@
 """Tithi (lunar day) calculations."""
 
-from ...i18n import get_translation
+from ..i18n.lang import get_translation
 
 
 def get_tithi_index(moon_lon: float, sun_lon: float) -> int:

--- a/vedic_time_engine/app/core/vara.py
+++ b/vedic_time_engine/app/core/vara.py
@@ -9,6 +9,8 @@ from zoneinfo import ZoneInfo
 
 from dateutil import parser
 
+from ..i18n.lang import get_translation as _translate, load_language
+
 
 _TRANSLATIONS: dict[str, dict[str, str]] = {}
 
@@ -20,17 +22,12 @@ def get_translation(key: str, lang: str) -> str:
     """
 
     if lang not in _TRANSLATIONS:
-        i18n_path = Path(__file__).resolve().parents[2] / "i18n" / f"{lang}.json"
-        if i18n_path.exists():
-            try:
-                with i18n_path.open("r", encoding="utf-8") as f:
-                    _TRANSLATIONS[lang] = json.load(f)
-            except json.JSONDecodeError:
-                _TRANSLATIONS[lang] = {}
-        else:
+        try:
+            _TRANSLATIONS[lang] = load_language(lang)
+        except FileNotFoundError:
             _TRANSLATIONS[lang] = {}
 
-    return _TRANSLATIONS[lang].get(key, key)
+    return _translate(key, lang)
 
 
 _EN_WEEKDAYS = [

--- a/vedic_time_engine/app/core/yoga.py
+++ b/vedic_time_engine/app/core/yoga.py
@@ -7,6 +7,8 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Dict
 
+from ..i18n.lang import get_translation as _translate, load_language
+
 I18N_DIR = Path(__file__).resolve().parents[2] / "i18n"
 
 
@@ -22,8 +24,7 @@ def _load_translations(lang: str) -> Dict[str, str]:
     path = I18N_DIR / f"{lang}.json"
     if path.exists():
         try:
-            with path.open("r", encoding="utf-8") as f:
-                return json.load(f)
+            return load_language(lang)
         except json.JSONDecodeError:
             return {}
     return {}
@@ -32,8 +33,7 @@ def _load_translations(lang: str) -> Dict[str, str]:
 def get_translation(key: str, lang: str = "en") -> str:
     """Return the translation for ``key`` in ``lang`` if available."""
 
-    translations = _load_translations(lang)
-    return translations.get(key, key)
+    return _translate(key, lang)
 
 
 def get_yoga_index(sun_lon: float, moon_lon: float) -> int:

--- a/vedic_time_engine/app/i18n/__init__.py
+++ b/vedic_time_engine/app/i18n/__init__.py
@@ -1,0 +1,2 @@
+from .lang import load_language, get_translation
+__all__ = ["load_language", "get_translation"]

--- a/vedic_time_engine/app/i18n/lang.py
+++ b/vedic_time_engine/app/i18n/lang.py
@@ -1,0 +1,20 @@
+import json
+from pathlib import Path
+
+_language_cache: dict[str, dict] = {}
+
+
+def load_language(lang: str) -> dict:
+    """Load the JSON file for the given language code and return as dict."""
+    base = Path(__file__).resolve().parents[2] / "i18n" / f"{lang}.json"
+    return json.loads(base.read_text(encoding="utf-8"))
+
+
+def get_translation(key: str, lang: str = "en") -> str:
+    """Retrieve the translated string for the given key in the specified language."""
+    if lang not in _language_cache:
+        try:
+            _language_cache[lang] = load_language(lang)
+        except FileNotFoundError:
+            _language_cache[lang] = {}
+    return _language_cache[lang].get(key, key)

--- a/vedic_time_engine/i18n/__init__.py
+++ b/vedic_time_engine/i18n/__init__.py
@@ -1,23 +1,3 @@
-import json
-from functools import lru_cache
-from pathlib import Path
+from ..app.i18n.lang import get_translation, load_language
 
-_I18N_DIR = Path(__file__).parent
-
-@lru_cache(maxsize=None)
-def _load_language(lang: str) -> dict:
-    """Load translation dictionary for a given language."""
-    path = _I18N_DIR / f"{lang}.json"
-    if not path.exists():
-        return {}
-    with open(path, "r", encoding="utf-8") as f:
-        try:
-            return json.load(f)
-        except json.JSONDecodeError:
-            return {}
-
-
-def get_translation(key: str, lang: str = "en") -> str:
-    """Return the translated string for the given key and language."""
-    translations = _load_language(lang)
-    return translations.get(key, key)
+__all__ = ["get_translation", "load_language"]


### PR DESCRIPTION
## Summary
- implement `load_language` and `get_translation` in `app/i18n/lang.py`
- expose these helpers via `app/i18n` and root `i18n` package
- refactor core modules to use centralized translation loader

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878ff438234832aaeac9e7fa307ebca