### PR TITLE
Connect widget to API

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,18 @@ pip install -r requirements.txt
 ```
 Run locally:
 ```bash
-uvicorn app.main:app --reload
+uvicorn vedic_time_engine.app.main:app --reload --port 8080
 ```
+
+### Widget
+In another terminal install the widget dependencies and start its dev server:
+
+```bash
+cd vedic-time-widget
+npm install
+VITE_ENGINE_BASE_URL=http://localhost:8080 npm run dev
+```
+The widget will fetch data from the running API.
 
 ### Docker
 Place Swiss Ephemeris data in `ephe/` before building or mount it at runtime.

--- a/vedic-time-widget/README.md
+++ b/vedic-time-widget/README.md
@@ -1,23 +1,27 @@
-# ✨ Welcome to Your Spark Template!
-You've just launched your brand-new Spark Template Codespace — everything’s fired up and ready for you to explore, build, and create with Spark!
+# Vedic Time Widget
 
-This template is your blank canvas. It comes with a minimal setup to help you get started quickly with Spark development.
+This React application displays daily Vedic time information fetched from the
+FastAPI backend provided in the repository. It supports offline mode and caches
+the latest successful response locally.
 
-🚀 What's Inside?
-- A clean, minimal Spark environment
-- Pre-configured for local development
-- Ready to scale with your ideas
-  
-🧠 What Can You Do?
+## Development
 
-Right now, this is just a starting point — the perfect place to begin building and testing your Spark applications.
+1. Install dependencies:
 
-🧹 Just Exploring?
-No problem! If you were just checking things out and don’t need to keep this code:
+   ```bash
+   npm install
+   ```
 
-- Simply delete your Spark.
-- Everything will be cleaned up — no traces left behind.
+2. Ensure the API is running (see the project root `README.md`). Then start the
+   widget in development mode. Set the API base URL via `VITE_ENGINE_BASE_URL`:
 
-📄 License For Spark Template Resources 
+   ```bash
+   VITE_ENGINE_BASE_URL=http://localhost:8080 npm run dev
+   ```
 
-The Spark Template files and resources from GitHub are licensed under the terms of the MIT license, Copyright GitHub, Inc.
+   The widget will be available at `http://localhost:5173` and will proxy
+   requests to the API.
+
+## License
+
+MIT

--- a/vedic-time-widget/src/lib/vedic-api.ts
+++ b/vedic-time-widget/src/lib/vedic-api.ts
@@ -36,7 +36,7 @@ function getTimezoneOffset(): string {
   const hours = Math.floor(Math.abs(offset) / 60);
   const minutes = Math.abs(offset) % 60;
   const sign = offset <= 0 ? '+' : '-';
-  
+
   return `${sign}${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`;
 }
 
@@ -54,47 +54,16 @@ export async function fetchVedicTime(
       lang: language
     });
 
-    // For demo purposes, we'll simulate API response since we don't have a real endpoint
-    // In production, this would be: const response = await fetch(`/vedic-time?${params}`);
-    
-    // Simulate API delay
-    await new Promise(resolve => setTimeout(resolve, 1000));
-    
-    // Mock response data
-    const now = new Date();
-    const mockData: VedicTimeData = {
-      date: now.toLocaleDateString('hi-IN', { 
-        day: '2-digit', 
-        month: 'long', 
-        year: 'numeric' 
-      }),
-      weekday: now.toLocaleDateString('hi-IN', { weekday: 'long' }),
-      tithi: {
-        name: 'शुक्ल चतुर्थी',
-        time_range: '04:34 – 05:12'
-      },
-      nakshatra: 'रोहिणी',
-      yoga: 'व्यतीपात',
-      karana: 'वणिज',
-      sunrise: '06:02',
-      sunset: '18:55',
-      rahukalam: {
-        start: '09:08',
-        end: '10:38'
-      },
-      abhijit_muhurta: {
-        start: '12:13',
-        end: '13:01'
-      },
-      ghati: Math.floor(Math.random() * 60),
-      vighati: Math.floor(Math.random() * 60),
-      festivals: Math.random() > 0.5 ? ['विनायक चतुर्थी'] : []
-    };
+    const baseUrl =
+      (import.meta as any).env.VITE_ENGINE_BASE_URL || 'http://localhost:8080';
+    const response = await fetch(`${baseUrl}/vedic-time?${params.toString()}`);
 
-    return {
-      success: true,
-      data: mockData
-    };
+    if (!response.ok) {
+      throw new Error(`API error: ${response.status}`);
+    }
+
+    const data: VedicTimeData = await response.json();
+    return { success: true, data };
   } catch (error) {
     return {
       success: false,
@@ -102,6 +71,7 @@ export async function fetchVedicTime(
     };
   }
 }
+
 
 export function getSystemLanguage(): string {
   const lang = navigator.language.toLowerCase();


### PR DESCRIPTION
## Summary
- wire up `fetchVedicTime` to call the FastAPI backend
- document running the API and widget together

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68822127be14832a8583dfeedb6f151f